### PR TITLE
Got attack script working on Linux.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 scapy
+ifaddr


### PR DESCRIPTION
Hey @robert! I spent some time debugging this and got this working on Linux. There two main issues:

1. The loopback interface in Linux is named differently (it's `lo`, rather than `lo0` on MacOS). 
2. By default, `scapy` sends packets out on the link-layer domain. This is normally fine, and for non-loopback interfaces, packets would make it to their destination correctly. However, because of the way that loopback is implemented in Linux, packets sent out using link-layer protocols don't actually get disassembled/assembled by the OS and don't make it applications listening on the loopback interface. (see https://scapy.readthedocs.io/en/latest/troubleshooting.html#i-can-t-ping-127-0-0-1-scapy-does-not-work-with-127-0-0-1-or-on-the-loopback-interface for more details)

Re: getting the localhost interface, I was a little fancier than I needed to be and get the loopback interface programmatically. Let me know if you'd rather it be something like:

``
if sys.platform == "darwin":
  "lo0"
else:
  "lo"
``
or something like that.